### PR TITLE
[Feat] - #34 루틴 추가 UI 작업

### DIFF
--- a/Cafebara-iOS/Cafebara-iOS.xcodeproj/project.pbxproj
+++ b/Cafebara-iOS/Cafebara-iOS.xcodeproj/project.pbxproj
@@ -103,6 +103,11 @@
 		F1F179982BCC1F0600292D91 /* RoutineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179972BCC1F0600292D91 /* RoutineView.swift */; };
 		F1F1799A2BCC1F2300292D91 /* RoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179992BCC1F2300292D91 /* RoutineViewController.swift */; };
 		F1F1799C2BCC1F4B00292D91 /* RoutineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F1799B2BCC1F4B00292D91 /* RoutineViewModel.swift */; };
+		F1F179A12BCD43C100292D91 /* AddRoutineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179A02BCD43C100292D91 /* AddRoutineView.swift */; };
+		F1F179A32BCD43D100292D91 /* AddRoutineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179A22BCD43D100292D91 /* AddRoutineViewController.swift */; };
+		F1F179A62BCE8D2500292D91 /* RoutineKeywordInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179A52BCE8D2500292D91 /* RoutineKeywordInfo.swift */; };
+		F1F179AA2BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179A92BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift */; };
+		F1F179B12BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179B02BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift */; };
 		F1FD4F8E2BB5878D009C3050 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FD4F8D2BB5878D009C3050 /* LoginViewController.swift */; };
 		F1FD4F932BB58841009C3050 /* CustomDropDownTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FD4F922BB58841009C3050 /* CustomDropDownTableViewCell.swift */; };
 		F1FD4F952BB58857009C3050 /* CustomDropDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FD4F942BB58857009C3050 /* CustomDropDownView.swift */; };
@@ -193,6 +198,11 @@
 		F1F179972BCC1F0600292D91 /* RoutineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineView.swift; sourceTree = "<group>"; };
 		F1F179992BCC1F2300292D91 /* RoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineViewController.swift; sourceTree = "<group>"; };
 		F1F1799B2BCC1F4B00292D91 /* RoutineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineViewModel.swift; sourceTree = "<group>"; };
+		F1F179A02BCD43C100292D91 /* AddRoutineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRoutineView.swift; sourceTree = "<group>"; };
+		F1F179A22BCD43D100292D91 /* AddRoutineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRoutineViewController.swift; sourceTree = "<group>"; };
+		F1F179A52BCE8D2500292D91 /* RoutineKeywordInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineKeywordInfo.swift; sourceTree = "<group>"; };
+		F1F179A92BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineKeywordCollectionViewCell.swift; sourceTree = "<group>"; };
+		F1F179B02BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		F1FD4F8D2BB5878D009C3050 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		F1FD4F922BB58841009C3050 /* CustomDropDownTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDownTableViewCell.swift; sourceTree = "<group>"; };
 		F1FD4F942BB58857009C3050 /* CustomDropDownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDownView.swift; sourceTree = "<group>"; };
@@ -750,6 +760,7 @@
 		F1D9A86D2BBAC49B00551905 /* Mission */ = {
 			isa = PBXGroup;
 			children = (
+				F1F1799D2BCD439800292D91 /* AddRoutineScene */,
 				F1F1798B2BCC1E6200292D91 /* RoutineScene */,
 				F1F1798A2BCC1CAF00292D91 /* MissionScene */,
 			);
@@ -860,6 +871,58 @@
 				F1F179912BCC1EA300292D91 /* RoutineCollectionViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		F1F1799D2BCD439800292D91 /* AddRoutineScene */ = {
+			isa = PBXGroup;
+			children = (
+				F1F179AF2BD0006300292D91 /* Component */,
+				F1F179A82BCE8DAD00292D91 /* Cell */,
+				F1F179A42BCE8D1000292D91 /* Model */,
+				F1F1799F2BCD43AE00292D91 /* ViewController */,
+				F1F1799E2BCD43A600292D91 /* View */,
+			);
+			path = AddRoutineScene;
+			sourceTree = "<group>";
+		};
+		F1F1799E2BCD43A600292D91 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				F1F179A02BCD43C100292D91 /* AddRoutineView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		F1F1799F2BCD43AE00292D91 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				F1F179A22BCD43D100292D91 /* AddRoutineViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		F1F179A42BCE8D1000292D91 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				F1F179A52BCE8D2500292D91 /* RoutineKeywordInfo.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		F1F179A82BCE8DAD00292D91 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				F1F179A92BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		F1F179AF2BD0006300292D91 /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				F1F179B02BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		F1FD4F8C2BB586D0009C3050 /* ViewController */ = {
@@ -1005,11 +1068,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1F179A32BCD43D100292D91 /* AddRoutineViewController.swift in Sources */,
 				F1D9A87B2BBBF74200551905 /* StaffMissionInfo.swift in Sources */,
 				F1FD4F952BB58857009C3050 /* CustomDropDownView.swift in Sources */,
 				A43C74002B90518800B39F21 /* BaseTargetType.swift in Sources */,
 				E58624222BC7B3EE004829AB /* AuthTarget.swift in Sources */,
+				F1F179AA2BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift in Sources */,
 				833DC7FA2B874CD50096703B /* FontLiterals.swift in Sources */,
+				F1F179A62BCE8D2500292D91 /* RoutineKeywordInfo.swift in Sources */,
 				A43C73F62B90515300B39F21 /* GeneralResponse.swift in Sources */,
 				A488FB462B9AFAF4004D4A09 /* CustomNavigationView.swift in Sources */,
 				A488FBAB2B9B81AB004D4A09 /* CustomToastMessage.swift in Sources */,
@@ -1024,6 +1090,7 @@
 				A41289E32B9F731300E3462D /* RoleChoiceViewController.swift in Sources */,
 				8304715A2B87BBC2005AEEB4 /* UIButton+.swift in Sources */,
 				F113CB4D2BA308C800FA6D71 /* MyWorkViewModel.swift in Sources */,
+				F1F179A12BCD43C100292D91 /* AddRoutineView.swift in Sources */,
 				F1D9A8822BBD6E8400551905 /* StaffMissionCollectionHeaderVIew.swift in Sources */,
 				833DC8042B874D5C0096703B /* UITableViewRegisterable.swift in Sources */,
 				E58624242BC7B43D004829AB /* AuthAPI.swift in Sources */,
@@ -1046,6 +1113,7 @@
 				F1D9A8742BBAC4E100551905 /* MissionViewController.swift in Sources */,
 				8304715E2B87BD22005AEEB4 /* UIImageView+.swift in Sources */,
 				833DC7FE2B874CED0096703B /* SizeLiterals.swift in Sources */,
+				F1F179B12BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */,
 				F190A4A42BB1635B006440F0 /* AskReplacementViewController.swift in Sources */,
 				F1D9A8802BBC021D00551905 /* StaffMissionCollectionViewCell.swift in Sources */,
 				833A6AF52B873317001370CD /* ViewController.swift in Sources */,

--- a/Cafebara-iOS/Cafebara-iOS.xcodeproj/project.pbxproj
+++ b/Cafebara-iOS/Cafebara-iOS.xcodeproj/project.pbxproj
@@ -81,7 +81,6 @@
 		A4BA86EE2BC3ADF00078FC4B /* CafeAllDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BA86ED2BC3ADF00078FC4B /* CafeAllDto.swift */; };
 		A4BA86F12BC40ECB0078FC4B /* HomeNoticeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BA86F02BC40ECB0078FC4B /* HomeNoticeCollectionViewCell.swift */; };
 		A4BA86F32BC411210078FC4B /* CafeNoticeDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BA86F22BC411210078FC4B /* CafeNoticeDto.swift */; };
-		A4BA86F52BC427720078FC4B /* ScheduleMyDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BA86F42BC427720078FC4B /* ScheduleMyDto.swift */; };
 		A4BA870B2BCCD52E0078FC4B /* HomeMemberScheduleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BA870A2BCCD52E0078FC4B /* HomeMemberScheduleCollectionViewCell.swift */; };
 		A4BA870D2BCCD5460078FC4B /* MemberScheduleDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BA870C2BCCD5460078FC4B /* MemberScheduleDto.swift */; };
 		E58624222BC7B3EE004829AB /* AuthTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58624212BC7B3EE004829AB /* AuthTarget.swift */; };
@@ -115,6 +114,7 @@
 		F1F179A62BCE8D2500292D91 /* RoutineKeywordInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179A52BCE8D2500292D91 /* RoutineKeywordInfo.swift */; };
 		F1F179AA2BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179A92BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift */; };
 		F1F179B12BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F179B02BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift */; };
+		F1F17A1B2BF2328800292D91 /* ScheduleMyDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F17A1A2BF2328800292D91 /* ScheduleMyDto.swift */; };
 		F1FD4F8E2BB5878D009C3050 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FD4F8D2BB5878D009C3050 /* LoginViewController.swift */; };
 		F1FD4F932BB58841009C3050 /* CustomDropDownTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FD4F922BB58841009C3050 /* CustomDropDownTableViewCell.swift */; };
 		F1FD4F952BB58857009C3050 /* CustomDropDownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FD4F942BB58857009C3050 /* CustomDropDownView.swift */; };
@@ -185,7 +185,6 @@
 		A4BA86ED2BC3ADF00078FC4B /* CafeAllDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeAllDto.swift; sourceTree = "<group>"; };
 		A4BA86F02BC40ECB0078FC4B /* HomeNoticeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNoticeCollectionViewCell.swift; sourceTree = "<group>"; };
 		A4BA86F22BC411210078FC4B /* CafeNoticeDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeNoticeDto.swift; sourceTree = "<group>"; };
-		A4BA86F42BC427720078FC4B /* ScheduleMyDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScheduleMyDto.swift; path = ../../../../../../../Downloads/ScheduleMyDto.swift; sourceTree = "<group>"; };
 		A4BA870A2BCCD52E0078FC4B /* HomeMemberScheduleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMemberScheduleCollectionViewCell.swift; sourceTree = "<group>"; };
 		A4BA870C2BCCD5460078FC4B /* MemberScheduleDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberScheduleDto.swift; sourceTree = "<group>"; };
 		E58624212BC7B3EE004829AB /* AuthTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTarget.swift; sourceTree = "<group>"; };
@@ -217,6 +216,7 @@
 		F1F179A52BCE8D2500292D91 /* RoutineKeywordInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineKeywordInfo.swift; sourceTree = "<group>"; };
 		F1F179A92BCE8E1B00292D91 /* RoutineKeywordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutineKeywordCollectionViewCell.swift; sourceTree = "<group>"; };
 		F1F179B02BD0008800292D91 /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
+		F1F17A1A2BF2328800292D91 /* ScheduleMyDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleMyDto.swift; sourceTree = "<group>"; };
 		F1FD4F8D2BB5878D009C3050 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		F1FD4F922BB58841009C3050 /* CustomDropDownTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDownTableViewCell.swift; sourceTree = "<group>"; };
 		F1FD4F942BB58857009C3050 /* CustomDropDownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropDownView.swift; sourceTree = "<group>"; };
@@ -710,7 +710,7 @@
 				A4BA86E92BC3A9090078FC4B /* MemberMyDto.swift */,
 				A4BA86ED2BC3ADF00078FC4B /* CafeAllDto.swift */,
 				A4BA86F22BC411210078FC4B /* CafeNoticeDto.swift */,
-				A4BA86F42BC427720078FC4B /* ScheduleMyDto.swift */,
+				F1F17A1A2BF2328800292D91 /* ScheduleMyDto.swift */,
 				A4BA870C2BCCD5460078FC4B /* MemberScheduleDto.swift */,
 			);
 			path = Home;
@@ -1174,7 +1174,7 @@
 				833DC8062B874D9A0096703B /* NSObject+.swift in Sources */,
 				8304715C2B87BBEB005AEEB4 /* UITextField+.swift in Sources */,
 				A43C73F42B90513900B39F21 /* Config.swift in Sources */,
-				A4BA86F52BC427720078FC4B /* ScheduleMyDto.swift in Sources */,
+				F1F17A1B2BF2328800292D91 /* ScheduleMyDto.swift in Sources */,
 				A43C73F82B90515D00B39F21 /* NetworkLoggerPlugin.swift in Sources */,
 				A43B232D2BA6A44600E15CC3 /* StoreInputViewController.swift in Sources */,
 				F13062922BA991EA00E5B680 /* MyWorkInfo.swift in Sources */,

--- a/Cafebara-iOS/Cafebara-iOS/Global/Literals/StringLiterals.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Global/Literals/StringLiterals.swift
@@ -68,9 +68,20 @@ enum I18N {
     }
     
     enum Routine {
-        static let missionNavigationTitle = "루틴"
+        static let routineNavigationTitle = "루틴"
         static let noRoutineLabel = "아직 등록된 루틴이 없어요"
         static let addRoutineLabel = "추가"
         static let routineDeleteAlertTitle = "작성한 루틴을\n정말 삭제하실 건가요?"
+    }
+    
+    enum AddRoutine {
+        static let addRoutineNavigationTitle = "루틴 추가"
+        static let workTitleLabel = "근무 라벨"
+        static let workManualLabel = "우측 수정하기를 눌러 추가된 라벨을 수정해 보세요!"
+        static let routineCategoryLabel = "루틴 항목"
+        static let routineTodoTextViewPlaceholder = "해야할 일을 적어 주세요!"
+        static let changeAddButtonTitle = "추가하기"
+        static let changeModifyButtonTitle = "수정하기"
+        static let addRoutineKeywordLabel = "새로 추가하기"
     }
 }

--- a/Cafebara-iOS/Cafebara-iOS/Global/Resources/Assets.xcassets/IconBara/ic_navi_modify.imageset/Contents.json
+++ b/Cafebara-iOS/Cafebara-iOS/Global/Resources/Assets.xcassets/IconBara/ic_navi_modify.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_navi_modify.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Cafebara-iOS/Cafebara-iOS/Global/Resources/Assets.xcassets/IconBara/ic_navi_modify.imageset/ic_navi_modify.svg
+++ b/Cafebara-iOS/Cafebara-iOS/Global/Resources/Assets.xcassets/IconBara/ic_navi_modify.imageset/ic_navi_modify.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_6351_13170)">
+<path d="M9.38764 4.51808L3.47197 10.4337L3.28711 12.7137L5.5671 12.5289L8.52494 9.57103L11.4828 6.61321M9.38764 4.51808L10.62 3.28564L12.7152 5.38078L11.4828 6.61321M9.38764 4.51808L11.4828 6.61321" stroke="#7A7D87" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_6351_13170">
+<rect width="11.3333" height="11.3333" fill="white" transform="translate(2.33398 2.33301)"/>
+</clipPath>
+</defs>
+</svg>

--- a/Cafebara-iOS/Cafebara-iOS/Network/Data/Home/ScheduleMyDto.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Network/Data/Home/ScheduleMyDto.swift
@@ -1,0 +1,27 @@
+//
+//  ScheduleMyDto.swift
+//  Cafebara-iOS
+//
+//  Created by 고아라 on 4/8/24.
+//
+
+import Foundation
+
+struct ScheduleMyDto: Codable {
+    let date: String
+    let hasSchedule: Bool
+}
+
+extension ScheduleMyDto {
+    static func scheduleMyDtoInitValue() -> [ScheduleMyDto] {
+        return [
+            ScheduleMyDto(date: "2024.04.14", hasSchedule: true),
+            ScheduleMyDto(date: "2024.04.15", hasSchedule: false),
+            ScheduleMyDto(date: "2024.04.16", hasSchedule: true),
+            ScheduleMyDto(date: "2024.04.17", hasSchedule: false),
+            ScheduleMyDto(date: "2024.04.18", hasSchedule: false),
+            ScheduleMyDto(date: "2024.04.19", hasSchedule: false),
+            ScheduleMyDto(date: "2024.04.20", hasSchedule: true)
+        ]
+    }
+}

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Common/CustomTabBar/TabBarItem.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Common/CustomTabBar/TabBarItem.swift
@@ -63,7 +63,7 @@ enum TabBarItem: CaseIterable {
     var targetViewController: UIViewController {
         switch self {
         case .home: 
-            return MyWorkViewController()
+            return ViewController()
         case .todo:
             return UserDefaults.standard.bool(forKey: "isOwner") ? MissionViewController() : ViewController()
         case .schedule:

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Cell/RoutineKeywordCollectionViewCell.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Cell/RoutineKeywordCollectionViewCell.swift
@@ -21,6 +21,21 @@ final class RoutineKeywordCollectionViewCell: UICollectionViewCell, UICollection
         case add
     }
     
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                routineKeywordLabel.textColor = routineKeywordLabelBackgroundColor
+                routineKeywordLabel.backgroundColor = routineKeywordLabelTextColor
+            } else {
+                routineKeywordLabel.textColor = routineKeywordLabelTextColor
+                routineKeywordLabel.backgroundColor = routineKeywordLabelBackgroundColor
+            }
+        }
+    }
+    
+    private var routineKeywordLabelTextColor: UIColor?
+    private var routineKeywordLabelBackgroundColor: UIColor?
+    
     // MARK: - UI Components
     
     private let backGroundView = UIView()
@@ -118,9 +133,10 @@ private extension RoutineKeywordCollectionViewCell {
 extension RoutineKeywordCollectionViewCell {
     
     func configureCell(data: RoutineKeywordInfo) {
-        
         if data.routineKeyword.count < 7 {
             routineKeywordLabel.text = data.routineKeyword
+            routineKeywordLabelTextColor = UIColor(hex: data.routineKeywordTextColor)
+            routineKeywordLabelBackgroundColor = UIColor(hex: data.routineKeywordBackColor)
             routineKeywordLabel.textColor = UIColor(hex: data.routineKeywordTextColor)
             routineKeywordLabel.backgroundColor = UIColor(hex: data.routineKeywordBackColor)
             setHierarchy(type: .add)

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Cell/RoutineKeywordCollectionViewCell.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Cell/RoutineKeywordCollectionViewCell.swift
@@ -1,0 +1,74 @@
+//
+//  AddRoutineKeywordCollectionViewCell.swift
+//  Cafebara-iOS
+//
+//  Created by 강민수 on 4/16/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class RoutineKeywordCollectionViewCell: UICollectionViewCell, UICollectionViewRegisterable {
+    
+    // MARK: - Properties
+    
+    static let isFromNib: Bool = false
+    
+    // MARK: - UI Components
+    
+    private let backGroundView = UIView()
+    private let routineKeywordLabel = CustomPaddingLabel(padding: UIEdgeInsets(top: 6, left: 14, bottom: 6, right: 14))
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setStyle()
+        setHierarchy()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+private extension RoutineKeywordCollectionViewCell {
+    
+    func setUI() {
+        
+    }
+    
+    func setStyle() {
+        routineKeywordLabel.do {
+            $0.font = .fontBara(.body2)
+            $0.asLineHeight(.body2)
+            $0.layer.cornerRadius = 24
+            $0.layer.masksToBounds = true
+        }
+    }
+    
+    func setHierarchy() {
+        addSubview(backGroundView)
+        backGroundView.addSubview(routineKeywordLabel)
+    }
+    
+    func setLayout() {
+        routineKeywordLabel.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension RoutineKeywordCollectionViewCell {
+    
+    func configureCell() {
+        
+    }
+}

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Cell/RoutineKeywordCollectionViewCell.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Cell/RoutineKeywordCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  AddRoutineKeywordCollectionViewCell.swift
+//  RoutineKeywordCollectionViewCell.swift
 //  Cafebara-iOS
 //
 //  Created by 강민수 on 4/16/24.
@@ -16,20 +16,25 @@ final class RoutineKeywordCollectionViewCell: UICollectionViewCell, UICollection
     
     static let isFromNib: Bool = false
     
+    enum KeywordCellType {
+        case select
+        case add
+    }
+    
     // MARK: - UI Components
     
     private let backGroundView = UIView()
     private let routineKeywordLabel = CustomPaddingLabel(padding: UIEdgeInsets(top: 6, left: 14, bottom: 6, right: 14))
+    private let addRoutineView = UIView()
+    private let addImageView = UIImageView()
+    private let addRoutineKeywordLabel = UILabel()
     
     // MARK: - Life Cycles
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        setUI()
         setStyle()
-        setHierarchy()
-        setLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -41,34 +46,89 @@ final class RoutineKeywordCollectionViewCell: UICollectionViewCell, UICollection
 
 private extension RoutineKeywordCollectionViewCell {
     
-    func setUI() {
-        
-    }
-    
     func setStyle() {
         routineKeywordLabel.do {
             $0.font = .fontBara(.body2)
             $0.asLineHeight(.body2)
-            $0.layer.cornerRadius = 24
+            $0.layer.cornerRadius = 16
             $0.layer.masksToBounds = true
+        }
+        
+        addRoutineView.do {
+            $0.backgroundColor = .whiteBara
+            $0.setRoundBorder(borderColor: .gray2,
+                              borderWidth: 1,
+                              cornerRadius: 12)
+        }
+        
+        addImageView.do {
+            $0.image = UIImage(resource: .icAdd16Gray3)
+        }
+        
+        addRoutineKeywordLabel.do {
+            $0.font = .fontBara(.caption1)
+            $0.asLineHeight(.caption1)
+            $0.textColor = .gray3
         }
     }
     
-    func setHierarchy() {
-        addSubview(backGroundView)
-        backGroundView.addSubview(routineKeywordLabel)
+    func setHierarchy(type: KeywordCellType) {
+        addSubviews(backGroundView)
+        
+        switch type {
+        case .add:
+            backGroundView.addSubviews(routineKeywordLabel)
+        case .select:
+            backGroundView.addSubviews(addRoutineView)
+            addRoutineView.addSubviews(addImageView,
+                                       addRoutineKeywordLabel)
+        }
     }
     
-    func setLayout() {
-        routineKeywordLabel.snp.makeConstraints {
+    func setLayout(type: KeywordCellType) {
+        backGroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        switch type {
+        case .add:
+            routineKeywordLabel.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+        case .select:
+            addRoutineView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+            
+            addImageView.snp.makeConstraints {
+                $0.top.bottom.equalToSuperview().inset(6)
+                $0.leading.equalToSuperview().inset(8)
+                $0.size.equalTo(16)
+            }
+            
+            addRoutineKeywordLabel.snp.makeConstraints {
+                $0.top.bottom.equalToSuperview().inset(6)
+                $0.leading.equalTo(addImageView.snp.trailing).offset(4)
+                $0.trailing.equalToSuperview().inset(8)
+            }
         }
     }
 }
 
 extension RoutineKeywordCollectionViewCell {
     
-    func configureCell() {
+    func configureCell(data: RoutineKeywordInfo) {
         
+        if data.routineKeyword.count < 7 {
+            routineKeywordLabel.text = data.routineKeyword
+            routineKeywordLabel.textColor = UIColor(hex: data.routineKeywordTextColor)
+            routineKeywordLabel.backgroundColor = UIColor(hex: data.routineKeywordBackColor)
+            setHierarchy(type: .add)
+            setLayout(type: .add)
+        } else {
+            addRoutineKeywordLabel.text = data.routineKeyword
+            setHierarchy(type: .select)
+            setLayout(type: .select)
+        }
     }
 }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Component/LeftAlignedCollectionViewFlowLayout.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Component/LeftAlignedCollectionViewFlowLayout.swift
@@ -5,4 +5,27 @@
 //  Created by 강민수 on 4/17/24.
 //
 
-import Foundation
+import UIKit
+
+class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
+    
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        let attributes = super.layoutAttributesForElements(in: rect)
+        var leftMargin: CGFloat = 0.0
+        var maxY: CGFloat = -1.0
+        
+        attributes?.forEach { layoutAttribute in
+            guard layoutAttribute.representedElementCategory == .cell else { return }
+            
+            if layoutAttribute.frame.origin.y >= maxY {
+                leftMargin = 0.0
+            }
+            
+            layoutAttribute.frame.origin.x = leftMargin
+            leftMargin += layoutAttribute.frame.width + minimumInteritemSpacing
+            maxY = max(layoutAttribute.frame.maxY, maxY)
+        }
+        
+        return attributes
+    }
+}

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Component/LeftAlignedCollectionViewFlowLayout.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Component/LeftAlignedCollectionViewFlowLayout.swift
@@ -1,0 +1,8 @@
+//
+//  LeftAlignedCollectionViewFlowLayout.swift
+//  Cafebara-iOS
+//
+//  Created by 강민수 on 4/17/24.
+//
+
+import Foundation

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Model/RoutineKeywordInfo.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Model/RoutineKeywordInfo.swift
@@ -1,5 +1,5 @@
 //
-//  AddRoutineKeywordInfo.swift
+//  RoutineKeywordInfo.swift
 //  Cafebara-iOS
 //
 //  Created by 강민수 on 4/16/24.
@@ -10,6 +10,5 @@ import Foundation
 struct RoutineKeywordInfo: Codable {
     let routineKeyword: String
     let routineKeywordTextColor: String
-    let routineKeywordDefaultBackColor: String
-    let routineKeywordSelectedBackColor: String
+    let routineKeywordBackColor: String
 }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Model/RoutineKeywordInfo.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/Model/RoutineKeywordInfo.swift
@@ -1,0 +1,15 @@
+//
+//  AddRoutineKeywordInfo.swift
+//  Cafebara-iOS
+//
+//  Created by 강민수 on 4/16/24.
+//
+
+import Foundation
+
+struct RoutineKeywordInfo: Codable {
+    let routineKeyword: String
+    let routineKeywordTextColor: String
+    let routineKeywordDefaultBackColor: String
+    let routineKeywordSelectedBackColor: String
+}

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
@@ -8,15 +8,24 @@
 import UIKit
 
 import SnapKit
-Import Then
+import Then
 
 final class AddRoutineView: UIView {
-
-    // MARK: - Properties
-    
     
     // MARK: - UI Components
     
+    let navigationBar = CustomNavigationView()
+    private let workTitleLabel = UILabel()
+    private let workManualImageView = UIImageView()
+    private let workManualLabel = UILabel()
+    let routineKeywordFixButton = UIButton()
+    let routineKeyworkCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    private let routineCategoryLabel = UILabel()
+    let routineTodoTextView = UITextView()
+    let routineTodoTextViewClearButton = UIButton()
+    let changeButton = CustomButton(status: false,
+                                 type: .noBorder,
+                                 title: I18N.AddRoutine.changeAddButtonTitle)
     
     // MARK: - Life Cycles
     
@@ -39,30 +48,157 @@ final class AddRoutineView: UIView {
 // MARK: - Extensions
 
 private extension AddRoutineView {
-
+    
     func setUI() {
-        
+        backgroundColor = .backgroundBara
     }
-
+    
     func setStyle() {
+        navigationBar.do {
+            $0.isBackButtonIncluded = true
+            $0.isTitleLabelIncluded = true
+            $0.titleLabelText = I18N.AddRoutine.addRoutineNavigationTitle
+        }
         
+        workTitleLabel.do {
+            $0.text = I18N.AddRoutine.workTitleLabel
+            $0.font = .fontBara(.body3)
+            $0.asLineHeight(.body3)
+            $0.textColor = .gray5
+        }
+        
+        workManualImageView.do {
+            $0.image = UIImage(resource: .icInfoWorklabel14)
+        }
+        
+        workManualLabel.do {
+            $0.text = I18N.AddRoutine.workManualLabel
+            $0.font = .fontBara(.caption2)
+            $0.asLineHeight(.caption2)
+            $0.textColor = .gray2
+        }
+        
+        routineKeywordFixButton.do {
+            $0.setImage(UIImage(resource: .icNaviModify), for: .normal)
+        }
+        
+        routineKeyworkCollectionView.do {
+            let layout = LeftAlignedCollectionViewFlowLayout()
+            layout.scrollDirection = .vertical
+            layout.minimumLineSpacing = 10.0
+            layout.minimumInteritemSpacing = 8.0
+            layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+            
+            $0.collectionViewLayout = layout
+            $0.contentInsetAdjustmentBehavior = .always
+            $0.backgroundColor = .backgroundBara
+            $0.showsVerticalScrollIndicator = false
+        }
+        
+        routineCategoryLabel.do {
+            $0.text = I18N.AddRoutine.routineCategoryLabel
+            $0.font = .fontBara(.body3)
+            $0.asLineHeight(.body3)
+            $0.textColor = .gray5
+        }
+        
+        routineTodoTextView.do {
+            $0.backgroundColor = .whiteBara
+            $0.setRoundBorder(borderColor: .gray1,
+                              borderWidth: 1.0,
+                              cornerRadius: 8)
+            $0.textContainerInset = UIEdgeInsets(top: 16,
+                                                 left: 16,
+                                                 bottom: 16,
+                                                 right: 16)
+            $0.text = I18N.AddRoutine.routineTodoTextViewPlaceholder
+            $0.font = .fontBara(.body3)
+            $0.textColor = .gray2
+            $0.isScrollEnabled = false
+            $0.sizeToFit()
+        }
+        
+        routineTodoTextViewClearButton.do {
+            $0.setImage(UIImage(resource: .icTextDeleteCircle), for: .normal)
+        }
     }
     
     func setHierarchy() {
-
+        addSubviews(navigationBar,
+                    workTitleLabel,
+                    workManualImageView,
+                    workManualLabel,
+                    routineKeywordFixButton,
+                    routineKeyworkCollectionView,
+                    routineCategoryLabel,
+                    routineTodoTextView,
+                    routineTodoTextViewClearButton,
+                    changeButton)
     }
     
     func setLayout() {
-
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        workTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        workManualImageView.snp.makeConstraints {
+            $0.top.equalTo(workTitleLabel.snp.bottom).offset(4)
+            $0.leading.equalToSuperview().inset(20)
+            $0.size.equalTo(14)
+        }
+        
+        workManualLabel.snp.makeConstraints {
+            $0.centerY.equalTo(workManualImageView)
+            $0.leading.equalTo(workManualImageView.snp.trailing).offset(2)
+        }
+        
+        routineKeywordFixButton.snp.makeConstraints {
+            $0.centerY.equalTo(workTitleLabel)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.size.equalTo(16)
+        }
+        
+        routineKeyworkCollectionView.snp.makeConstraints {
+            $0.top.equalTo(workTitleLabel.snp.bottom).offset(36)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(74) // TODO: 이후 수정
+        }
+        
+        routineCategoryLabel.snp.makeConstraints {
+            $0.top.equalTo(routineKeyworkCollectionView.snp.bottom).offset(48)
+            $0.leading.equalToSuperview().inset(20)
+        }
+        
+        routineTodoTextView.snp.makeConstraints {
+            $0.top.equalTo(routineCategoryLabel.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        routineTodoTextViewClearButton.snp.makeConstraints {
+            $0.centerY.equalTo(routineTodoTextView)
+            $0.trailing.equalTo(routineTodoTextView).inset(16)
+            $0.size.equalTo(24)
+        }
+        
+        changeButton.snp.makeConstraints {
+            $0.bottom.equalTo(safeAreaLayoutGuide).offset(-14)
+            $0.centerX.equalToSuperview()
+        }
     }
     
     func setRegisterCell() {
-        
+        RoutineKeywordCollectionViewCell.register(target: routineKeyworkCollectionView)
     }
 }
 
 extension AddRoutineView {
-
+    
     func configureView() {
         
     }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
@@ -110,7 +110,7 @@ private extension AddRoutineView {
             $0.textContainerInset = UIEdgeInsets(top: 16,
                                                  left: 16,
                                                  bottom: 16,
-                                                 right: 16)
+                                                 right: 56)
             $0.text = I18N.AddRoutine.routineTodoTextViewPlaceholder
             $0.font = .fontBara(.body3)
             $0.textColor = .gray2
@@ -120,6 +120,7 @@ private extension AddRoutineView {
         
         routineTodoTextViewClearButton.do {
             $0.setImage(UIImage(resource: .icTextDeleteCircle), for: .normal)
+            $0.isHidden = true
         }
     }
     

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
@@ -140,7 +140,7 @@ private extension AddRoutineView {
     func setLayout() {
         navigationBar.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
-            $0.leading.trailing.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
         }
         
         workTitleLabel.snp.makeConstraints {

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/View/AddRoutineView.swift
@@ -1,0 +1,69 @@
+//
+//  AddRoutineView.swift
+//  Cafebara-iOS
+//
+//  Created by 강민수 on 4/15/24.
+//
+
+import UIKit
+
+import SnapKit
+Import Then
+
+final class AddRoutineView: UIView {
+
+    // MARK: - Properties
+    
+    
+    // MARK: - UI Components
+    
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setStyle()
+        setHierarchy()
+        setLayout()
+        setRegisterCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+private extension AddRoutineView {
+
+    func setUI() {
+        
+    }
+
+    func setStyle() {
+        
+    }
+    
+    func setHierarchy() {
+
+    }
+    
+    func setLayout() {
+
+    }
+    
+    func setRegisterCell() {
+        
+    }
+}
+
+extension AddRoutineView {
+
+    func configureView() {
+        
+    }
+}

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -42,6 +42,11 @@ final class AddRoutineViewController: UIViewController {
         setUI()
         bindViewModel()
         setDelegate()
+        setGesture()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
     }
 }
 
@@ -86,9 +91,41 @@ extension AddRoutineViewController {
                 }
             }
             .disposed(by: disposeBag)
+        
+        addRoutineView.routineTodoTextView.rx.text.orEmpty
+            .subscribe(onNext: { [weak self] text in
+                guard let self = self else { return }
+                
+                if text.count > 30 {
+                    let index = text.index(text.startIndex, offsetBy: 30)
+                    let newText = text[text.startIndex..<index]
+                    self.addRoutineView.routineTodoTextView.text = String(newText)
+                }
+                
+                if text.count == 0 && addRoutineView.routineTodoTextView.textColor == UIColor.gray7 {
+                    addRoutineView.routineTodoTextViewClearButton.isHidden = true
+                } else if text.count != 0 && addRoutineView.routineTodoTextView.textColor == UIColor.gray7 {
+                    addRoutineView.routineTodoTextViewClearButton.isHidden = false
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func setGesture() {
+        addRoutineView.navigationBar.backButtonAction = {
+            self.navigationController?.popViewController(animated: true)
+        }
+        
+        addRoutineView.routineTodoTextViewClearButton.rx.tap
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                
+                self.addRoutineView.routineTodoTextView.text = ""
+                self.addRoutineView.routineTodoTextView.becomeFirstResponder()
+            }
+            .disposed(by: disposeBag)
     }
     
     func setDelegate() {
-//        RoutineKeywordCollectionViewCell.register(target: addRoutineView.routineKeyworkCollectionView)
     }
 }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -7,18 +7,33 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
+
 final class AddRoutineViewController: UIViewController {
     
     // MARK: - Properties
     
+    private var viewModel: RoutineViewModel
+    private let disposeBag = DisposeBag()
     
     // MARK: - UI Components
     
+    private let addRoutineView = AddRoutineView()
     
     // MARK: - Life Cycles
     
+    init(viewModel: RoutineViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func loadView() {
-        
+        view = addRoutineView
     }
     
     override func viewDidLoad() {
@@ -33,16 +48,47 @@ final class AddRoutineViewController: UIViewController {
 // MARK: - Extensions
 
 extension AddRoutineViewController {
-
+    
     func setUI() {
-        
+        self.navigationController?.navigationBar.isHidden = true
+        self.tabBarController?.tabBar.isHidden = true
     }
-
+    
     func bindViewModel() {
-	
+        viewModel.outputs.routineKeywordInfo
+            .bind(to: addRoutineView.routineKeyworkCollectionView.rx.items) { collectionView, index, item in
+                let indexPath = IndexPath(item: index, section: 0)
+                let cell = RoutineKeywordCollectionViewCell.dequeueReusableCell(collectionView: collectionView, indexPath: indexPath)
+                cell.configureCell(data: item)
+                
+                return cell
+            }
+            .disposed(by: disposeBag)
+        
+        addRoutineView.routineTodoTextView.rx.didBeginEditing
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                if addRoutineView.routineTodoTextView.textColor == UIColor.gray2 {
+                    self.addRoutineView.routineTodoTextView.text = nil
+                    self.addRoutineView.routineTodoTextView.textColor = .gray7
+                    self.addRoutineView.routineTodoTextView.layer.borderColor = UIColor.gray5.cgColor
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        addRoutineView.routineTodoTextView.rx.didEndEditing
+            .bind { [weak self] _ in
+                guard let self = self else { return }
+                if addRoutineView.routineTodoTextView.text.isEmpty {
+                    self.addRoutineView.routineTodoTextView.text = I18N.AddRoutine.routineTodoTextViewPlaceholder
+                    self.addRoutineView.routineTodoTextView.textColor = .gray2
+                    self.addRoutineView.routineTodoTextView.layer.borderColor = UIColor.gray1.cgColor
+                }
+            }
+            .disposed(by: disposeBag)
     }
     
     func setDelegate() {
-        
+//        RoutineKeywordCollectionViewCell.register(target: addRoutineView.routineKeyworkCollectionView)
     }
 }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -41,7 +41,6 @@ final class AddRoutineViewController: UIViewController {
         
         setUI()
         bindViewModel()
-        setDelegate()
         setGesture()
     }
     

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -125,6 +125,19 @@ extension AddRoutineViewController {
                 }
             })
             .disposed(by: disposeBag)
+        
+        Observable.combineLatest(addRoutineView.routineTodoTextView.rx.text.orEmpty, addRoutineView.routineKeyworkCollectionView.rx.itemSelected) { (text, indexPath) in
+            return (text, indexPath)
+        }
+        .bind { [weak self] (text, indexPath) in
+            guard let self = self else { return }
+            if self.addRoutineView.routineTodoTextView.textColor == .gray7 && !text.isEmpty {
+                self.addRoutineView.changeButton.isEnabled = true
+            } else {
+                self.addRoutineView.changeButton.isEnabled = false
+            }
+        }
+        .disposed(by: disposeBag)
     }
     
     func setGesture() {

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -70,6 +70,22 @@ extension AddRoutineViewController {
             }
             .disposed(by: disposeBag)
         
+        addRoutineView.routineKeyworkCollectionView.rx.itemSelected
+            .bind { [weak self] indexPath in
+                guard let self = self else { return }
+                let cell = RoutineKeywordCollectionViewCell.dequeueReusableCell(collectionView: self.addRoutineView.routineKeyworkCollectionView, indexPath: indexPath)
+                cell.isSelected = true
+            }
+            .disposed(by: disposeBag)
+        
+        addRoutineView.routineKeyworkCollectionView.rx.itemDeselected
+            .bind { [weak self] indexPath in
+                guard let self = self else { return }
+                let cell = RoutineKeywordCollectionViewCell.dequeueReusableCell(collectionView: self.addRoutineView.routineKeyworkCollectionView, indexPath: indexPath)
+                cell.isSelected = false
+            }
+            .disposed(by: disposeBag)
+        
         addRoutineView.routineTodoTextView.rx.didBeginEditing
             .bind { [weak self] _ in
                 guard let self = self else { return }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -129,7 +129,7 @@ extension AddRoutineViewController {
         Observable.combineLatest(addRoutineView.routineTodoTextView.rx.text.orEmpty, addRoutineView.routineKeyworkCollectionView.rx.itemSelected) { (text, indexPath) in
             return (text, indexPath)
         }
-        .bind { [weak self] (text, indexPath) in
+        .bind { [weak self] (text, _) in
             guard let self = self else { return }
             if self.addRoutineView.routineTodoTextView.textColor == .gray7 && !text.isEmpty {
                 self.addRoutineView.changeButton.isEnabled = true
@@ -138,6 +138,19 @@ extension AddRoutineViewController {
             }
         }
         .disposed(by: disposeBag)
+        
+        if viewModel.isEditing {
+            self.addRoutineView.changeButton.setTitle(I18N.AddRoutine.changeModifyButtonTitle, for: .normal)
+            self.addRoutineView.routineTodoTextView.textColor = .gray7
+            self.addRoutineView.routineTodoTextView.layer.borderColor = UIColor.gray5.cgColor
+            viewModel.outputs.modifyRoutineKeywordInfo
+                .bind { [weak self] info in
+                    guard let self = self else { return }
+                    guard let info = info else { return }
+                    self.addRoutineView.routineTodoTextView.text = info.routineExplain
+                }
+                .disposed(by: disposeBag)
+        }
     }
     
     func setGesture() {

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -1,0 +1,48 @@
+//
+//  AddRoutineViewController.swift
+//  Cafebara-iOS
+//
+//  Created by 강민수 on 4/15/24.
+//
+
+import UIKit
+
+final class AddRoutineViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    
+    // MARK: - UI Components
+    
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        bindViewModel()
+        setDelegate()
+    }
+}
+
+// MARK: - Extensions
+
+extension AddRoutineViewController {
+
+    func setUI() {
+        
+    }
+
+    func bindViewModel() {
+	
+    }
+    
+    func setDelegate() {
+        
+    }
+}

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/AddRoutineScene/ViewController/AddRoutineViewController.swift
@@ -167,7 +167,4 @@ extension AddRoutineViewController {
             }
             .disposed(by: disposeBag)
     }
-    
-    func setDelegate() {
-    }
 }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/View/RoutineView.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/View/RoutineView.swift
@@ -52,7 +52,7 @@ private extension RoutineView {
         navigationBar.do {
             $0.isBackButtonIncluded = true
             $0.isTitleLabelIncluded = true
-            $0.titleLabelText = I18N.Routine.missionNavigationTitle
+            $0.titleLabelText = I18N.Routine.routineNavigationTitle
         }
         
         noRoutineImageView.do {

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewController/RoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewController/RoutineViewController.swift
@@ -77,6 +77,7 @@ extension RoutineViewController {
                     .when(.recognized)
                     .bind { [weak self] _ in
                         guard let self = self else { return }
+                        viewModel.inputs.isEditMode(bool: false)
                         self.navigationController?.pushViewController(AddRoutineViewController(viewModel: viewModel), animated: true)
                     }
                     .disposed(by: self.disposeBag)
@@ -84,6 +85,18 @@ extension RoutineViewController {
                 return headerView
             }
         )
+        
+        routineView.routineCollectionView.rx.itemSelected
+            .map { indexPath in
+                return dataSource[indexPath]
+            }
+            .subscribe(onNext: { [weak self] item in
+                guard let self = self else { return }
+                self.viewModel.modifyRoutineKeywordInfo.onNext(item)
+                viewModel.inputs.isEditMode(bool: true)
+                self.navigationController?.pushViewController(AddRoutineViewController(viewModel: viewModel), animated: true)
+            })
+            .disposed(by: disposeBag)
         
         viewModel.outputs.routineInfo
             .bind(to: routineView.routineCollectionView.rx.items(dataSource: dataSource))

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewController/RoutineViewController.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewController/RoutineViewController.swift
@@ -73,6 +73,13 @@ extension RoutineViewController {
             },
             configureSupplementaryView: { (_, collectionView, _, indexPath) in
                 let headerView = RoutineCollectionHeaderView.dequeueReusableHeaderView(collectionView: collectionView, indexPath: indexPath)
+                headerView.addRoutineView.rx.tapGesture()
+                    .when(.recognized)
+                    .bind { [weak self] _ in
+                        guard let self = self else { return }
+                        self.navigationController?.pushViewController(AddRoutineViewController(viewModel: viewModel), animated: true)
+                    }
+                    .disposed(by: self.disposeBag)
                 
                 return headerView
             }

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewModel/RoutineViewModel.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewModel/RoutineViewModel.swift
@@ -16,6 +16,8 @@ protocol RoutineViewModelInputs {
 
 protocol RoutineViewModelOutputs {
     var routineInfo: BehaviorSubject<[SectionOfRoutine]> { get }
+    var routineKeywordInfo: BehaviorSubject<[RoutineKeywordInfo]> { get }
+    var routineKeywordCollectionViewHeight: PublishRelay<Int> { get }
 }
 
 protocol RoutineViewModelType {
@@ -34,6 +36,8 @@ final class RoutineViewModel: RoutineViewModelInputs, RoutineViewModelOutputs, R
     
     // output
     var routineInfo = BehaviorSubject<[SectionOfRoutine]>(value: [])
+    var routineKeywordInfo = BehaviorSubject<[RoutineKeywordInfo]>(value: [])
+    var routineKeywordCollectionViewHeight = PublishRelay<Int>()
     
     init() {
         let routineInfoDTO: [RoutineInfo] = [
@@ -48,6 +52,16 @@ final class RoutineViewModel: RoutineViewModelInputs, RoutineViewModelOutputs, R
             RoutineInfo(routineKeyword: "미들", routineKeywordTextColor: "#FF4F4F", routineKeywordBackColor: "#FFF3F3", routineExplain: "미들에는 그냥 몰래몰래 쉬는거야~")
         ]
         routineInfo.onNext([SectionOfRoutine(items: routineInfoDTO)])
+        
+        let routineKeywordInfoDTO: [RoutineKeywordInfo] = [
+            RoutineKeywordInfo(routineKeyword: "오픈", routineKeywordTextColor: "#1F9BB6", routineKeywordBackColor: "#EAFBFA"),
+            RoutineKeywordInfo(routineKeyword: "미들", routineKeywordTextColor: "#6CB731", routineKeywordBackColor: "#F6FEF3"),
+            RoutineKeywordInfo(routineKeyword: "마감", routineKeywordTextColor: "#D14892", routineKeywordBackColor: "#FFF3FD"),
+            RoutineKeywordInfo(routineKeyword: "오픈오픈오픈", routineKeywordTextColor: "#7827C9", routineKeywordBackColor: "#F6F1FD"),
+            RoutineKeywordInfo(routineKeyword: "미들미들미들", routineKeywordTextColor: "#FF4F4F", routineKeywordBackColor: "#FFF3F3"),
+            RoutineKeywordInfo(routineKeyword: I18N.AddRoutine.addRoutineKeywordLabel, routineKeywordTextColor: "#FF4F4F", routineKeywordBackColor: "#FFF3F3")
+        ]
+        routineKeywordInfo.onNext(routineKeywordInfoDTO)
     }
 }
 

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewModel/RoutineViewModel.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewModel/RoutineViewModel.swift
@@ -12,12 +12,13 @@ import RxSwift
 import RxRelay
 
 protocol RoutineViewModelInputs {
+    func isEditMode(bool: Bool)
 }
 
 protocol RoutineViewModelOutputs {
     var routineInfo: BehaviorSubject<[SectionOfRoutine]> { get }
     var routineKeywordInfo: BehaviorSubject<[RoutineKeywordInfo]> { get }
-    var routineKeywordCollectionViewHeight: PublishRelay<Int> { get }
+    var modifyRoutineKeywordInfo: BehaviorSubject<RoutineInfo?> { get }
 }
 
 protocol RoutineViewModelType {
@@ -32,12 +33,17 @@ final class RoutineViewModel: RoutineViewModelInputs, RoutineViewModelOutputs, R
     
     private let disposeBag = DisposeBag()
     
+    var isEditing: Bool = false
+    
     // input
+    func isEditMode(bool: Bool) {
+        isEditing = bool
+    }
     
     // output
     var routineInfo = BehaviorSubject<[SectionOfRoutine]>(value: [])
     var routineKeywordInfo = BehaviorSubject<[RoutineKeywordInfo]>(value: [])
-    var routineKeywordCollectionViewHeight = PublishRelay<Int>()
+    var modifyRoutineKeywordInfo = BehaviorSubject<RoutineInfo?>(value: nil)
     
     init() {
         let routineInfoDTO: [RoutineInfo] = [

--- a/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewModel/RoutineViewModel.swift
+++ b/Cafebara-iOS/Cafebara-iOS/Presentation/Mission/RoutineScene/ViewModel/RoutineViewModel.swift
@@ -59,7 +59,7 @@ final class RoutineViewModel: RoutineViewModelInputs, RoutineViewModelOutputs, R
             RoutineKeywordInfo(routineKeyword: "마감", routineKeywordTextColor: "#D14892", routineKeywordBackColor: "#FFF3FD"),
             RoutineKeywordInfo(routineKeyword: "오픈오픈오픈", routineKeywordTextColor: "#7827C9", routineKeywordBackColor: "#F6F1FD"),
             RoutineKeywordInfo(routineKeyword: "미들미들미들", routineKeywordTextColor: "#FF4F4F", routineKeywordBackColor: "#FFF3F3"),
-            RoutineKeywordInfo(routineKeyword: I18N.AddRoutine.addRoutineKeywordLabel, routineKeywordTextColor: "#FF4F4F", routineKeywordBackColor: "#FFF3F3")
+            RoutineKeywordInfo(routineKeyword: "새로 추가하기", routineKeywordTextColor: "", routineKeywordBackColor: "")
         ]
         routineKeywordInfo.onNext(routineKeywordInfoDTO)
     }


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

- 루틴 키워드 Cell의 좌측 정렬을 위해 LeftAlignedCollectionViewFlowLayout를 구현했습니다.
- 루틴 키워드 Cell의 '새로 추가하기'와 구별하기 위해서 **글자 수**를 기준으로 작업했습니다. 루틴 키워드 Cell의 키워드는 6글자로 제한되기 때문에 위와 같은 방식을 했습니다. 서로 다른 UICollectionViewCell을 구현하는 방법을 아시거나 혹은 더 좋은 방법이 있다면 피드백 주시면 좋을 것 같습니다.
```swift
if data.routineKeyword.count < 7
```
- 루틴 항목을 작성하는 칸을 만들기 위해서 TextView를 사용했습니다. TextField는 기본적으로 한줄 입력만 제공합니다. 따라서 TextView를 이용했습니다. 하지만 TextView는 placeholder를 지원하지 않기 때문에 placeholder의 기능을 제공하기 위하여 사용자가 입력하는 경우와 입력이 끝났을 경우 글자의 색상을 변경하여 적용했습니다.
```swift
        addRoutineView.routineTodoTextView.rx.didBeginEditing
            .bind { [weak self] _ in
                guard let self = self else { return }
                if addRoutineView.routineTodoTextView.textColor == UIColor.gray2 {
                    self.addRoutineView.routineTodoTextView.text = nil
                    self.addRoutineView.routineTodoTextView.textColor = .gray7
                    self.addRoutineView.routineTodoTextView.layer.borderColor = UIColor.gray5.cgColor
                }
            }
            .disposed(by: disposeBag)
        
        addRoutineView.routineTodoTextView.rx.didEndEditing
            .bind { [weak self] _ in
                guard let self = self else { return }
                if addRoutineView.routineTodoTextView.text.isEmpty {
                    self.addRoutineView.routineTodoTextView.text = I18N.AddRoutine.routineTodoTextViewPlaceholder
                    self.addRoutineView.routineTodoTextView.textColor = .gray2
                    self.addRoutineView.routineTodoTextView.layer.borderColor = UIColor.gray1.cgColor
                }
            }
            .disposed(by: disposeBag)
    }
```
- 같은 화면을 루틴 추가와 수정 기능이 가능하도록 만들어져 viewModel의 변수인 isEditing에 따라 UI가 분리되도록 했습니다. 해당 변수는 추후 통신할 경우 isEditing의 변수에 따라 post과 put에 관련된 통신을 보내야 할때 유용하게 사용될 것으로 보입니다.



🚨 **참고 사항**
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- 루틴 선택했을 경우 취소가 되지 않고 단일 선택이 되도록 하였습니다. 해당 화면에서는 **필수적**으로 루틴을 하나 선택 해야하므로 선택 취소에 대한 기능은 구현하지 않았습니다. 만약 필요할 경우 추후 수정하도록 하겠습니다.
- 기능적인 부분에서 피드백은 언제나 환영입니다. 날카로운 지적 언제든지 환영합니다. 부탁드립니다.


💭 **PR 유형**
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


✅ **Checklist**
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?

📸 **스크린샷**
|스크린샷|SE|13mini|14|15Pro|
|:--:|:--:|:--:|:--:|:--:|
|GIF| ![fncnSE](https://github.com/TeamCafebara/Cafebara-iOS/assets/62370742/daf1df6a-93d1-430d-978e-60567938d856)| ![fncn13mini](https://github.com/TeamCafebara/Cafebara-iOS/assets/62370742/f99c3d7c-4530-4bc9-bffa-419ed1c04c80)|![fncn14](https://github.com/TeamCafebara/Cafebara-iOS/assets/62370742/cc218e80-bcd6-4144-942c-d1b272c4360d) | ![fncn15pro](https://github.com/TeamCafebara/Cafebara-iOS/assets/62370742/0701bb49-a470-4994-8306-5e6265326fa3)|

📟 **관련 이슈**
- Resolved: #34 
